### PR TITLE
fix: zip-extract dir is '<repo>-<branch>', not '<branch>-<branch>' (FileNotFoundError on cold cache)

### DIFF
--- a/ovos_docs_viewer/ovos_docs.py
+++ b/ovos_docs_viewer/ovos_docs.py
@@ -127,7 +127,10 @@ def download_docs(force: bool = False) -> Dict[str, str]:
                 f.write(response.content)
 
             with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-                extracted_name = url.split("/")[-1].replace(".zip", "-master")
+                # GitHub branch archives extract to "<repo>-<branch>", not "<branch>-<branch>"
+                repo_name = url.split("/archive/")[0].split("/")[-1]
+                branch = url.split("/")[-1].replace(".zip", "")
+                extracted_name = f"{repo_name}-{branch}"
                 zip_ref.extractall(base_path)
                 shutil.move(base_path / extracted_name, doc_folder)
             zip_path.unlink()


### PR DESCRIPTION
`extracted_name = url.split('/')[-1].replace('.zip','-master')` produces `master-master` for a `.../archive/refs/heads/master.zip` URL, but GitHub extracts to `<repo>-master`, so `shutil.move()` hits a nonexistent path → `FileNotFoundError`. `ovos-docs-viewer technical` (and `messages`, `hivemind`) crash on a cold cache. Fix derives the dir from the repo + branch. Found auditing for the Technical Manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved documentation downloads from GitHub archives by correctly locating extracted files across different repository branches.
  - Ensured downloaded documentation is placed in the appropriate destination directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->